### PR TITLE
Prototype Bugfix - fixed issue with SharedPreferences

### DIFF
--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/AccountCreation.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/AccountCreation.java
@@ -1,7 +1,9 @@
 package pilot.cs262.calvin.edu.knightrank;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
@@ -17,9 +19,9 @@ public class AccountCreation extends AppCompatActivity {
     private static final String LOG_TAG =
             MainActivity.class.getSimpleName();
 
-    private static final String USER_NAME = "";
-    private static final String USER_PASSWORD = "";
-    private static final String CONFIRM_PASSWORD = "";
+    private static final String USER_NAME_CREATION = "user name creation";
+    private static final String USER_PASSWORD_CREATION = "user password creation";
+    private static final String CONFIRM_PASSWORD = "confirm password";
 
     private EditText username;
     private EditText password;
@@ -27,7 +29,7 @@ public class AccountCreation extends AppCompatActivity {
 
     // Share preferences file.
     private SharedPreferences mPreferences;
-    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
+    private static final String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -53,11 +55,12 @@ public class AccountCreation extends AppCompatActivity {
 
         // Set shared preferences component.
         mPreferences = getSharedPreferences(sharedPrefFile, MODE_PRIVATE);
+        //mPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
         // Restores user name and user password from saved preferences file.
-        username.setText(mPreferences.getString(USER_NAME, ""));
-        password.setText(mPreferences.getString(USER_PASSWORD, ""));
-        confirmPassword.setText(mPreferences.getString(CONFIRM_PASSWORD, ""));
+        username.setText(mPreferences.getString(USER_NAME_CREATION, "User name"));
+        password.setText(mPreferences.getString(USER_PASSWORD_CREATION, "User password"));
+        confirmPassword.setText(mPreferences.getString(CONFIRM_PASSWORD, "User password"));
     }
 
     /**
@@ -109,13 +112,13 @@ public class AccountCreation extends AppCompatActivity {
     protected void onPause() {
         super.onPause();
 
-        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+        SharedPreferences.Editor preferencesEditor2 = mPreferences.edit();
 
-        preferencesEditor.putString(USER_NAME, username.getText().toString());
-        preferencesEditor.putString(USER_PASSWORD, password.getText().toString());
-        preferencesEditor.putString(CONFIRM_PASSWORD, confirmPassword.getText().toString());
+        preferencesEditor2.putString(USER_NAME_CREATION, username.getText().toString());
+        preferencesEditor2.putString(USER_PASSWORD_CREATION, password.getText().toString());
+        preferencesEditor2.putString(CONFIRM_PASSWORD, confirmPassword.getText().toString());
 
-        preferencesEditor.apply();
+        preferencesEditor2.apply();
     }
 
     /**

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ActivityRankings.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ActivityRankings.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.Fragment;
@@ -28,13 +29,13 @@ public class ActivityRankings extends AppCompatActivity
             ActivityRankings.class.getSimpleName();
 
     // For use with shared preferences.
-    private static final String PLACEHOLDER1 = "";
+    private static final String PLACEHOLDER1 = "placeholder1";
 
     private DrawerLayout mDrawerLayout;
 
     // Share preferences file.
     private SharedPreferences mPreferences;
-    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
+    private static final String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -70,6 +71,7 @@ public class ActivityRankings extends AppCompatActivity
 
         // Set shared preferences component.
         mPreferences = getSharedPreferences(sharedPrefFile, MODE_PRIVATE);
+        //mPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
         // Placeholder code as example of how to restore values to UI components from shared preferences.
         //username_main.setText(mPreferences.getString(USER_NAME, ""));
@@ -258,10 +260,10 @@ public class ActivityRankings extends AppCompatActivity
     protected void onPause() {
         super.onPause();
 
-        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+        SharedPreferences.Editor preferencesEditor3 = mPreferences.edit();
 
-        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+        preferencesEditor3.putString(PLACEHOLDER1, "Placeholder text 1");
 
-        preferencesEditor.apply();
+        preferencesEditor3.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ActivitySelection.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ActivitySelection.java
@@ -2,6 +2,7 @@ package pilot.cs262.calvin.edu.knightrank;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
@@ -16,11 +17,11 @@ public class ActivitySelection extends AppCompatActivity {
             ActivitySelection.class.getSimpleName();
 
     // For use with shared preferences.
-    private static final String PLACEHOLDER1 = "";
+    private static String PLACEHOLDER5 = "";
 
     // Share preferences file.
     private SharedPreferences mPreferences;
-    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
+    private static final String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -41,6 +42,7 @@ public class ActivitySelection extends AppCompatActivity {
 
         // Set shared preferences component.
         mPreferences = getSharedPreferences(sharedPrefFile, MODE_PRIVATE);
+        //mPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
         // Placeholder code as example of how to restore values to UI components from shared preferences.
         //username_main.setText(mPreferences.getString(USER_NAME, ""));
@@ -68,10 +70,10 @@ public class ActivitySelection extends AppCompatActivity {
     public void onPause() {
         super.onPause();
 
-        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+        SharedPreferences.Editor preferencesEditor7 = mPreferences.edit();
 
-        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+        preferencesEditor7.putString(PLACEHOLDER5, "Placeholder text 5");
 
-        preferencesEditor.apply();
+        preferencesEditor7.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ChallengeResults.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/ChallengeResults.java
@@ -2,6 +2,7 @@ package pilot.cs262.calvin.edu.knightrank;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.os.Bundle;
@@ -16,11 +17,11 @@ public class ChallengeResults extends Fragment {
     // Class variables.
 
     // For use with shared preferences.
-    private static final String PLACEHOLDER1 = "";
+    private static String PLACEHOLDER2 = "";
 
     // Share preferences file.
     private SharedPreferences mPreferences;
-    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
+    private static final String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -30,6 +31,7 @@ public class ChallengeResults extends Fragment {
         // Set shared preferences component.
         // Note: modified from the one in activities as this is a fragment.
         mPreferences = Objects.requireNonNull(this.getActivity()).getSharedPreferences(sharedPrefFile, Context.MODE_PRIVATE);
+        //mPreferences = PreferenceManager.getDefaultSharedPreferences(this.getActivity());
 
         // Placeholder code as example of how to restore values to UI components from shared preferences.
         //username_main.setText(mPreferences.getString(USER_NAME, ""));
@@ -51,10 +53,10 @@ public class ChallengeResults extends Fragment {
     public void onPause() {
         super.onPause();
 
-        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+        SharedPreferences.Editor preferencesEditor4 = mPreferences.edit();
 
-        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+        preferencesEditor4.putString(PLACEHOLDER2, "Placeholder text 2");
 
-        preferencesEditor.apply();
+        preferencesEditor4.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/MainActivity.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
@@ -18,15 +19,15 @@ public class MainActivity extends AppCompatActivity {
     private static final String LOG_TAG =
             MainActivity.class.getSimpleName();
 
-    private static final String USER_NAME = "";
-    private static final String USER_PASSWORD = "";
+    private static final String USER_NAME = "user_name";
+    private static final String USER_PASSWORD = "user_password";
 
     private EditText username_main;
     private EditText password_main;
 
     // Share preferences file.
     private SharedPreferences mPreferences;
-    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
+    private static final String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -43,10 +44,11 @@ public class MainActivity extends AppCompatActivity {
 
         // Set shared preferences component.
         mPreferences = getSharedPreferences(sharedPrefFile, MODE_PRIVATE);
+        //mPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
         // Restores user name and user password from saved preferences file.
-        username_main.setText(mPreferences.getString(USER_NAME, ""));
-        password_main.setText(mPreferences.getString(USER_PASSWORD, ""));
+        username_main.setText(mPreferences.getString(USER_NAME, "My user name"));
+        password_main.setText(mPreferences.getString(USER_PASSWORD, "My user password"));
     }
 
     /**
@@ -98,12 +100,12 @@ public class MainActivity extends AppCompatActivity {
     protected void onPause() {
         super.onPause();
 
-        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+        SharedPreferences.Editor preferencesEditor1 = mPreferences.edit();
 
-        preferencesEditor.putString(USER_NAME, username_main.getText().toString());
-        preferencesEditor.putString(USER_PASSWORD, username_main.getText().toString());
+        preferencesEditor1.putString(USER_NAME, username_main.getText().toString());
+        preferencesEditor1.putString(USER_PASSWORD, password_main.getText().toString());
 
-        preferencesEditor.apply();
+        preferencesEditor1.apply();
     }
 
     /**

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/MyRankings.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/MyRankings.java
@@ -2,6 +2,7 @@ package pilot.cs262.calvin.edu.knightrank;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.os.Bundle;
@@ -16,11 +17,11 @@ public class MyRankings extends Fragment {
     // Class variables.
 
     // For use with shared preferences.
-    private static final String PLACEHOLDER1 = "";
+    private static String PLACEHOLDER6 = "";
 
     // Share preferences file.
     private SharedPreferences mPreferences;
-    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
+    private static final String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -30,6 +31,7 @@ public class MyRankings extends Fragment {
         // Set shared preferences component.
         // Note: modified from the one in activities as this is a fragment.
         mPreferences = Objects.requireNonNull(this.getActivity()).getSharedPreferences(sharedPrefFile, Context.MODE_PRIVATE);
+        //mPreferences = PreferenceManager.getDefaultSharedPreferences(this.getActivity());
 
         // Placeholder code as example of how to restore values to UI components from shared preferences.
         //username_main.setText(mPreferences.getString(USER_NAME, ""));
@@ -51,10 +53,10 @@ public class MyRankings extends Fragment {
     public void onPause() {
         super.onPause();
 
-        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+        SharedPreferences.Editor preferencesEditor8 = mPreferences.edit();
 
-        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+        preferencesEditor8.putString(PLACEHOLDER6, "Placeholder text 6");
 
-        preferencesEditor.apply();
+        preferencesEditor8.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/NewChallenges.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/NewChallenges.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -28,11 +29,11 @@ public class NewChallenges extends Fragment {
     private static final String ARG_PARAM2 = "param2";
 
     // For use with shared preferences.
-    private static final String PLACEHOLDER1 = "";
+    private static final String PLACEHOLDER3 = "";
 
     // Share preferences file.
     private SharedPreferences mPreferences;
-    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
+    private static final String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     // TODO: Rename and change types of parameters
     private String mParam1;
@@ -73,6 +74,7 @@ public class NewChallenges extends Fragment {
         // Set shared preferences component.
         // Note: modified from the one in activities as this is a fragment.
         mPreferences = Objects.requireNonNull(this.getActivity()).getSharedPreferences(sharedPrefFile, Context.MODE_PRIVATE);
+        //mPreferences = PreferenceManager.getDefaultSharedPreferences(this.getActivity());
 
         // Placeholder code as example of how to restore values to UI components from shared preferences.
         //username_main.setText(mPreferences.getString(USER_NAME, ""));
@@ -132,10 +134,10 @@ public class NewChallenges extends Fragment {
     public void onPause() {
         super.onPause();
 
-        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+        SharedPreferences.Editor preferencesEditor5 = mPreferences.edit();
 
-        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+        preferencesEditor5.putString(PLACEHOLDER3, "Placeholder text 3");
 
-        preferencesEditor.apply();
+        preferencesEditor5.apply();
     }
 }

--- a/app/src/main/java/pilot/cs262/calvin/edu/knightrank/RecentChallenges.java
+++ b/app/src/main/java/pilot/cs262/calvin/edu/knightrank/RecentChallenges.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -28,11 +29,11 @@ public class RecentChallenges extends Fragment {
     private static final String ARG_PARAM2 = "param2";
 
     // For use with shared preferences.
-    private static final String PLACEHOLDER1 = "";
+    private static String PLACEHOLDER4 = "";
 
     // Share preferences file.
     private SharedPreferences mPreferences;
-    private String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
+    private static final String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     // TODO: Rename and change types of parameters
     private String mParam1;
@@ -73,6 +74,7 @@ public class RecentChallenges extends Fragment {
         // Set shared preferences component.
         // Note: modified from the one in activities as this is a fragment.
         mPreferences = Objects.requireNonNull(this.getActivity()).getSharedPreferences(sharedPrefFile, Context.MODE_PRIVATE);
+        //mPreferences = PreferenceManager.getDefaultSharedPreferences(this.getActivity());
 
         // Placeholder code as example of how to restore values to UI components from shared preferences.
         //username_main.setText(mPreferences.getString(USER_NAME, ""));
@@ -132,10 +134,10 @@ public class RecentChallenges extends Fragment {
     public void onPause() {
         super.onPause();
 
-        SharedPreferences.Editor preferencesEditor = mPreferences.edit();
+        SharedPreferences.Editor preferencesEditor6 = mPreferences.edit();
 
-        preferencesEditor.putString(PLACEHOLDER1, "Placeholder text");
+        preferencesEditor6.putString(PLACEHOLDER4, "Placeholder text 4");
 
-        preferencesEditor.apply();
+        preferencesEditor6.apply();
     }
 }


### PR DESCRIPTION
Prototype Bugfix - fixed issue with SharedPreferences

-SharedPreferences now accesses, saves, and restores key-value pairs properly across all activites/fragments

-Fixed issue where when MainActivity is accessed via drawer navigation, it would not restore the proper key-value pairs associated with the EditTextFields
and would instead resort to the default values defined in the .java file.

-Fixed issue where AccountCreation were restoring key-value pairs for MainActivity EditTextFields rather than AccountCreation's EditTextFields

-Resolved by making variable name private static final for the String variable defining the name of the SharedPreferences file.

-Resolved by not being an idiot and getting text from the user name field instead of the password field in MainAcitivity.java when storing key-value pairs.

-Key names should be private static final as they should be UNIQUE immutable objects used only with SharedPreferences.

Note: The SharedPreferences file is shared across the app so ensure all key names are UNIQUE!!!!!

Resources Used:

https://github.com/google-developer-training/android-fundamentals/blob/master/HelloSharedPrefs/app/src/main/java/com/example/android/hellosharedprefs/MainActivity.java