### PR TITLE
Color Picker Activity toolbar and background color now also changes

### DIFF
--- a/app/src/main/java/edu/calvin/cs262/pilot/knightrank/ActivityMain.java
+++ b/app/src/main/java/edu/calvin/cs262/pilot/knightrank/ActivityMain.java
@@ -115,8 +115,6 @@ public class ActivityMain extends AppCompatActivity
         Log.e(LOG_TAG,"Value of color is: " + value);
     }
 
-
-
     /**
      * Method adds an options menu to the toolbar.
      *

--- a/app/src/main/java/edu/calvin/cs262/pilot/knightrank/ColorPicker.java
+++ b/app/src/main/java/edu/calvin/cs262/pilot/knightrank/ColorPicker.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
@@ -16,6 +17,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
@@ -106,6 +108,20 @@ public class ColorPicker extends AppCompatActivity implements SeekBar.OnSeekBarC
         // Placeholder code as example of how to restore values to UI components from shared preferences.
         //username_main.setText(mPreferences.getString(USER_NAME, ""));
         //password_main.setText(mPreferences.getString(USER_PASSWORD, ""));
+
+        // Change the background color to what was selected in color picker.
+        // Note: Change color by using findViewById and ID of the UI element you wish to change.
+        RelativeLayout thisLayout = findViewById(R.id.activity_color_picker_root_layout);
+        thisLayout.setBackgroundColor(mPreferences.getInt(ColorPicker.APP_BACKGROUND_COLOR_ARGB, Color.WHITE));
+
+        int value = mPreferences.getInt(ColorPicker.APP_BACKGROUND_COLOR_ARGB, Color.BLACK);
+
+        int toolbarColor = mPreferences.getInt(ColorPicker.APP_TOOLBAR_COLOR_ARGB, Color.RED);
+
+        // Change the toolbar color to what was selected in color picker.
+        getSupportActionBar().setBackgroundDrawable(new ColorDrawable(toolbarColor));
+
+        Log.e(LOG_TAG,"Value of color is: " + value);
     }
 
     /**

--- a/app/src/main/java/edu/calvin/cs262/pilot/knightrank/SettingsActivity.java
+++ b/app/src/main/java/edu/calvin/cs262/pilot/knightrank/SettingsActivity.java
@@ -3,8 +3,10 @@ package edu.calvin.cs262.pilot.knightrank;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
@@ -13,6 +15,8 @@ import android.os.Bundle;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
+import android.support.v4.view.GravityCompat;
+import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
@@ -20,7 +24,9 @@ import android.preference.RingtonePreference;
 import android.support.v7.preference.SeekBarPreference;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
 import android.view.MenuItem;
 import android.support.v4.app.NavUtils;
 import android.view.View;
@@ -42,6 +48,21 @@ import java.util.List;
  * API Guide</a> for more information on developing a Settings UI.
  */
 public class SettingsActivity extends AppCompatPreferenceActivity {
+
+    //Class variables.
+    private static final String LOG_TAG =
+            SettingsActivity.class.getSimpleName();
+
+    // For use with shared preferences.
+    private static final String PLACEHOLDER1 = "placeholder1";
+
+    // Share preferences file (custom)
+    private SharedPreferences mPreferences;
+    // Shared preferences file (default)
+    private SharedPreferences mPreferencesDefault;
+
+    // Name of the custom shared preferences file.
+    private static final String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     // Static string variables to hold the key for various settings
     // (used to retrieve the relevant values when in other .java classes)
@@ -134,6 +155,32 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setupActionBar();
+        setTheme(R.style.AppTheme);
+        // Set shared preferences component.
+        mPreferences = getSharedPreferences(sharedPrefFile, MODE_PRIVATE);
+        mPreferencesDefault = android.support.v7.preference.PreferenceManager.getDefaultSharedPreferences(this);
+
+        // Placeholder code as example of how to get values from the default SharedPrefs file.
+        String syncFreq = mPreferencesDefault.getString(SettingsActivity.KEY_SYNC_FREQUENCY, "-1");
+
+        // Placeholder code as example of how to restore values to UI components from shared preferences.
+        //username_main.setText(mPreferences.getString(USER_NAME, ""));
+        //password_main.setText(mPreferences.getString(USER_PASSWORD, ""));
+
+        // Change the background color to what was selected in color picker.
+        // Note: Change color by using findViewById and ID of the UI element you wish to change.
+        //LinearLayout thisLayout = findViewById(R.id.fragment_activity_rankings_root_layout);
+        //thisLayout.setBackgroundColor(mPreferences.getInt(ColorPicker.APP_BACKGROUND_COLOR_ARGB, Color.WHITE));
+
+        int value = mPreferences.getInt(ColorPicker.APP_BACKGROUND_COLOR_ARGB, Color.BLACK);
+
+        int toolbarColor = mPreferences.getInt(ColorPicker.APP_TOOLBAR_COLOR_ARGB, Color.RED);
+
+        // Change the toolbar color to what was selected in color picker.
+        //getSupportActionBar().setBackgroundDrawable(new ColorDrawable(toolbarColor));
+
+        Log.e(LOG_TAG,"Value of color is: " + value);
+
     }
 
     /**
@@ -141,11 +188,59 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
      */
     private void setupActionBar() {
 
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            // Show the Up button in the action bar.
-            actionBar.setDisplayHomeAsUpEnabled(true);
+        // my_child_toolbar is defined in the layout file
+        Toolbar myToolbar = findViewById(R.id.my_toolbar);
+        setSupportActionBar(myToolbar);
+
+        // Get a support ActionBar corresponding to this toolbar
+        ActionBar ab = getSupportActionBar();
+
+        // Enable the Up button
+        if (ab != null) {
+            ab.setDisplayHomeAsUpEnabled(true);
         }
+
+        // Custom icon for the Up button
+        if (ab != null) {
+            ab.setHomeAsUpIndicator(R.drawable.ic_menu_black_24dp);
+        }
+    }
+
+    /**
+     * Method adds an options menu to the toolbar.
+     *
+     * @param menu menu object
+     * @return true
+     */
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.menu_main, menu);
+        return true;
+    }
+
+    /**
+     * Method to control what happens when menu items are selected.
+     *
+     * @param item the item selected
+     * @return whatever
+     */
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        // The action bar home/up action should open or close the drawer.
+        switch (item.getItemId()) {
+            case R.id.color_picker:
+                Intent intent2 = new Intent(this, ColorPicker.class);
+                startActivity(intent2);
+                return true;
+            case R.id.online_help_system:
+                Intent intent3 = new Intent(this, OnlineHelpSystem.class);
+                startActivity(intent3);
+                return true;
+            default:
+                // Do nothing
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/res/layout/activity_color_picker.xml
+++ b/app/src/main/res/layout/activity_color_picker.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_margin="5dp"
+    android:id="@+id/activity_color_picker_root_layout"
     tools:context=".ColorPicker">
 
     <android.support.v7.widget.Toolbar


### PR DESCRIPTION
Color Picker Activity toolbar and background color now also changes

-Background color and toolbar color of the Color Picker Activity will also change when the user select a color.
(Note: requires exiting and returning to the color picker before the change will occur; since it's performed in OnCreate lifecycle)

-Settings Activity lacks a typical layout .xml file so usual method of applying color picker changes cannot be used.

-TODO: Remove SettingsActivity template entirely and create a custom settings activity with fragments.
(or just remove settings entirely as we don't have time to really implement any beyond placeholder items)