### PR TITLE
Implemented Resolve Matches as part of Drawer Nav

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,12 +23,10 @@
         android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
         tools:ignore="GoogleAppIndexingWarning">
         <!-- Below label controls the display name of the application's icon -->
-        <activity android:name=".ConfirmCheckboxActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+        <activity
+            android:name=".ConfirmCheckboxActivity"
+            android:label="Resolve Matches"
+            android:parentActivityName=".ActivityMain">
         </activity>
         <activity
             android:name=".SplashScreen"

--- a/app/src/main/java/edu/calvin/cs262/pilot/knightrank/ActivityMain.java
+++ b/app/src/main/java/edu/calvin/cs262/pilot/knightrank/ActivityMain.java
@@ -200,6 +200,10 @@ public class ActivityMain extends AppCompatActivity
             case R.id.nav_match_history:
                 fragment = new PastChallenges();
                 break;
+            case R.id.nav_resolve_matches:
+                Intent intent5 = new Intent(getApplicationContext(), ConfirmCheckboxActivity.class);
+                startActivity(intent5);
+                return true;
             case R.id.nav_switch_account:
                 // Build out GoogleSignIn object and sign out the user
                 GoogleSignInOptions gso = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)

--- a/app/src/main/java/edu/calvin/cs262/pilot/knightrank/ConfirmCheckboxActivity.java
+++ b/app/src/main/java/edu/calvin/cs262/pilot/knightrank/ConfirmCheckboxActivity.java
@@ -2,23 +2,100 @@ package edu.calvin.cs262.pilot.knightrank;
 
 import android.app.Dialog;
 import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.preference.PreferenceManager;
+import android.support.v7.widget.Toolbar;
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.ListView;
+import android.widget.RelativeLayout;
+
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Class ConfirmCheckBoxActivity defines an activity that allows resolution of match results
+ * between different users by allowing the user to confirm the final scores of the match(es).
+ *
+ * Note: Is not currently integrated with the back-end and button functionality are placeholder.
+ *
+ * Note: To the developer of this class, this should be a fragment, not an activity.
+ */
 public class ConfirmCheckboxActivity extends AppCompatActivity {
+
+    //Class variables.
+    private static final String LOG_TAG =
+            ConfirmCheckboxActivity.class.getSimpleName();
+
+    // For use with shared preferences.
+    private static final String PLACEHOLDER1 = "placeholder1";
+
+    // Share preferences file (custom)
+    private SharedPreferences mPreferences;
+    // Shared preferences file (default)
+    private SharedPreferences mPreferencesDefault;
+
+    // Name of the custom shared preferences file.
+    private static final String sharedPrefFile = "pilot.cs262.calvin.edu.knightrank";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.fragment_confirm_match);
+        setContentView(R.layout.activity_confirm_match);
+
+        // my_child_toolbar is defined in the layout file
+        Toolbar myToolbar = findViewById(R.id.my_toolbar);
+        setSupportActionBar(myToolbar);
+
+        // Get a support ActionBar corresponding to this toolbar
+        ActionBar ab = getSupportActionBar();
+
+        // Enable the Up button
+        if (ab != null) {
+            ab.setDisplayHomeAsUpEnabled(true);
+        }
+
+        // Custom icon for the Up button
+        if (ab != null) {
+            ab.setHomeAsUpIndicator(R.drawable.ic_menu_black_24dp);
+        }
+
+        // Set shared preferences component.
+        mPreferences = getSharedPreferences(sharedPrefFile, MODE_PRIVATE);
+        mPreferencesDefault = PreferenceManager.getDefaultSharedPreferences(this);
+
+        // Placeholder code as example of how to get values from the default SharedPrefs file.
+        String syncFreq = mPreferencesDefault.getString(SettingsActivity.KEY_SYNC_FREQUENCY, "-1");
+
+        // Placeholder code as example of how to restore values to UI components from shared preferences.
+        //username_main.setText(mPreferences.getString(USER_NAME, ""));
+        //password_main.setText(mPreferences.getString(USER_PASSWORD, ""));
+
+        // Change the background color to what was selected in color picker.
+        // Note: Change color by using findViewById and ID of the UI element you wish to change.
+        RelativeLayout thisLayout = findViewById(R.id.fragment_challenge_confirmation_root_layout);
+        thisLayout.setBackgroundColor(mPreferences.getInt(ColorPicker.APP_BACKGROUND_COLOR_ARGB, Color.WHITE));
+
+        int value = mPreferences.getInt(ColorPicker.APP_BACKGROUND_COLOR_ARGB, Color.BLACK);
+
+        int toolbarColor = mPreferences.getInt(ColorPicker.APP_TOOLBAR_COLOR_ARGB, Color.RED);
+
+        // Change the toolbar color to what was selected in color picker.
+        getSupportActionBar().setBackgroundDrawable(new ColorDrawable(toolbarColor));
+
+        Log.e(LOG_TAG,"Value of color is: " + value);
 
         setTitle("Confirm Results");
 
@@ -161,5 +238,46 @@ public class ConfirmCheckboxActivity extends AppCompatActivity {
             ret.add(dto);
         }
         return ret;
+    }
+
+    /**
+     * Method adds an options menu to the toolbar.
+     *
+     * @param menu menu object
+     * @return true
+     */
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.menu_main, menu);
+        return true;
+    }
+
+    /**
+     * Method to control what happens when menu items are selected.
+     *
+     * @param item the item selected
+     * @return whatever
+     */
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        // The action bar home/up action should open or close the drawer.
+        switch (item.getItemId()) {
+            case R.id.settings:
+                Intent intent1 = new Intent(this, SettingsActivity.class);
+                startActivity(intent1);
+                return true;
+            case R.id.color_picker:
+                Intent intent2 = new Intent(this, ColorPicker.class);
+                startActivity(intent2);
+                return true;
+            case R.id.online_help_system:
+                Intent intent3 = new Intent(this, OnlineHelpSystem.class);
+                startActivity(intent3);
+                return true;
+            default:
+                // Do nothing
+        }
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/res/layout/activity_confirm_match.xml
+++ b/app/src/main/res/layout/activity_confirm_match.xml
@@ -1,17 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/fragment_challenge_confirmation_root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/colorBackground">
 
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/my_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
+
     <TextView
         android:id="@+id/challenge_confirmation_textview"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginStart="0dp"
+        android:layout_marginTop="69dp"
+        android:padding="5dp"
         android:text="@string/unresolved_matches"
-        android:textSize="24sp"
-        android:padding="5dp"/>
+        android:textSize="24sp" />
 
     <ListView
         android:id="@+id/list_view_with_checkbox"

--- a/app/src/main/res/menu/drawer_view.xml
+++ b/app/src/main/res/menu/drawer_view.xml
@@ -31,6 +31,9 @@
             android:id="@+id/nav_switch_account"
             android:icon="@drawable/ic_android_black_24dp"
             android:title="@string/sign_out" />
-
+        <item
+            android:id="@+id/nav_resolve_matches"
+            android:icon="@drawable/ic_android_black_24dp"
+            android:title="Resolve Matches" />
     </group>
 </menu>


### PR DESCRIPTION
Implemented Resolve Matches as part of Drawer Nav

======================================================================

-Modified AndroidManifest.xml so it is NOT the default launcher and main activity.

-Modified ConfirmCheckboxActivity.java to be consistent with other app activities/fragments.

-Integrated ConfirmCheckboxActivity.java to be part of ActivityMain.java's Drawer Navigation.

-ColorPicker changes now affect ConfirmCheckboxActivity.java

-Added JavaDoc header to ConfirmCheckboxActivity.java

-Renamed layout to "activity_" rather than "fragment_" as it is a activity, not a fragment.
(note to developer of this class: refactor as a fragment)

-Added toolbar/actionbar and up navigation to this activity.

-Modified layout.xml file to allow room for toolbar/actionbar.

-Other minor edits and changes to be consistent with other .java classes

======================================================================

Note: Does this replace the other "Confirm Matches" fragment or is that a different functionality?